### PR TITLE
Centralize EventHandler contract

### DIFF
--- a/src/core/event-bus.ts
+++ b/src/core/event-bus.ts
@@ -3,26 +3,12 @@
  * Event bus and event handler interfaces
  */
 
-import { Event } from './contracts';
+import { Event, EventHandler } from './contracts';
 
 /**
  * Event handler interface
  * Each process manager or projection implements this interface to handle specific event types
  */
-export interface EventHandler<E extends Event = Event> {
-  /**
-   * Check if this handler supports the given event
-   * @param event The event to check
-   * @returns True if this handler supports the event, false otherwise
-   */
-  supportsEvent(event: Event): event is E;
-
-  /**
-   * Handle the event
-   * @param event The event to handle
-   */
-  handle(event: E): Promise<void>;
-}
 
 /**
  * Event bus

--- a/src/core/order/services/order.service.ts
+++ b/src/core/order/services/order.service.ts
@@ -7,7 +7,7 @@ import { Command, Event, UUID } from '../../contracts';
 import { CommandPort, EventPort, EventStorePort, EventPublisherPort } from '../../ports';
 import { OrderAggregate } from '../aggregates/order.aggregate';
 import { CommandHandler } from '../../command-bus';
-import { EventHandler } from '../../event-bus';
+import { EventHandler } from '../../contracts';
 import { createAggregatePayload } from '../../aggregates';
 import {BaseAggregate} from "../../base/aggregate";
 

--- a/src/infra/temporal/workflow-router.ts
+++ b/src/infra/temporal/workflow-router.ts
@@ -3,7 +3,7 @@ import {Connection, WorkflowClient, WorkflowIdReusePolicy} from '@temporalio/cli
 import {SagaRegistry} from '../../core/domains';
 import {Command, Event, UUID} from '../../core/contracts';
 import {CommandHandler} from '../../core/command-bus';
-import {EventHandler} from '../../core/event-bus';
+import {EventHandler} from '../../core/contracts';
 import {BaseAggregate} from "../../core/base/aggregate";
 
 // Define the result type for the workflow


### PR DESCRIPTION
## Summary
- remove duplicate `EventHandler` from event-bus
- reference contract definition in order service and workflow router

## Testing
- `npm run build`
- `npm run test:core`
